### PR TITLE
repaired recording of flv in appending mode

### DIFF
--- a/src/main/java/org/red5/io/flv/impl/FLVWriter.java
+++ b/src/main/java/org/red5/io/flv/impl/FLVWriter.java
@@ -746,6 +746,13 @@ public class FLVWriter implements ITagWriter {
 			} else {
 				// TODO update duration
 				log.warn("Adjustment of duration on append is not supported at this time");
+
+				if (dataFile != null) {
+					// If it is append mode we should change do bytesTransferred != 0
+					// because bytesTransferred == 0 means an error
+					// FIXME should be set only last recorded part as bytesTransferred
+					bytesTransferred = dataFile.getChannel().size();
+				}
 			}	
 			// close and remove the ser file if write was successful
 			if (dataFile != null && bytesTransferred > 0) {


### PR DESCRIPTION
*The steps to reproduce the problem:*
1. Record publishing video in appending mode.
2. Stop recording.
3. Record publishing video in appending mode to the file with the same filename.
4. Stop recording again.

*Expected*
After first stop there is flv-file with first part of your recording.
After second stop there is flv-file with both parts of your recording.

*Instead of:*
After first stop there is flv-file with first part of your recording.
After second stop flv-file has disappeared.

*Additional:*
When FLVWriter closes file last one should be finalized (finalizeFlv). This method is considered successful if it is returned value of transferred bytes > 0. But in appending mode there is no ser-file and data is writing into flv-file, so there is no bytes transferred from ser-file to flv-file and return value is 0. As a workaround I set number of transferred bytes equal size of flv-file.