### PR TITLE
Changed semaphore to reentrant lock in FLVReader

### DIFF
--- a/src/main/java/org/red5/io/flv/impl/FLVReader.java
+++ b/src/main/java/org/red5/io/flv/impl/FLVReader.java
@@ -657,7 +657,7 @@ public class FLVReader implements IoConstants, ITagReader, IKeyFrameDataAnalyzer
 			return keyframeMeta;
 		}
 		try {
-			lock.acquire();
+			lock.lockInterruptibly();
 			// check for cached keyframe informations
 			if (keyframeCache != null) {
 				keyframeMeta = keyframeCache.loadKeyFrameMeta(file);
@@ -777,7 +777,7 @@ public class FLVReader implements IoConstants, ITagReader, IKeyFrameDataAnalyzer
 		} catch (InterruptedException e) {
 			log.warn("Exception acquiring lock", e);
 		} finally {
-			lock.release();
+			lock.unlock();
 		}
 		return keyframeMeta;
 	}


### PR DESCRIPTION
I believe ReentrantLock is more appropriate than Semaphore in this case.
I have used this code for two years on server with 2 million of reading flv-files per day.