### PR TITLE
Play buffered interframes when playback starts between two keyframes

### DIFF
--- a/src/main/java/org/red5/codec/AVCVideo.java
+++ b/src/main/java/org/red5/codec/AVCVideo.java
@@ -18,6 +18,10 @@
 
 package org.red5.codec;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.apache.mina.core.buffer.IoBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,6 +46,16 @@ public class AVCVideo implements IVideoStreamCodec {
 	
 	/** Video decoder configuration data */
 	private FrameData decoderConfiguration;
+
+	/**
+	 * Storage for frames buffered since last key frame
+	 */
+	private final List<FrameData> interframes = new ArrayList<FrameData>(50);
+
+	/**
+	 * Number of frames buffered since last key frame
+	 */
+	private final AtomicInteger numInterframes = new AtomicInteger(0);
 
 	/** Constructs a new AVCVideo. */
 	public AVCVideo() {
@@ -88,6 +102,7 @@ public class AVCVideo implements IVideoStreamCodec {
     		// check for keyframe
     		if ((frameType & 0xf0) == FLV_FRAME_KEY) {
     			log.trace("Key frame found");
+				numInterframes.set(0);
 				byte AVCPacketType = data.get();
 				// rewind
 				data.rewind();
@@ -102,6 +117,19 @@ public class AVCVideo implements IVideoStreamCodec {
 				}
    				// store last keyframe
    				keyframe.setData(data);
+    		} else {
+    			data.rewind();
+    			try {
+        			int lastInterframe = numInterframes.getAndIncrement();
+        			log.trace("Buffering interframe #{}", lastInterframe);
+        			if (interframes.size() < lastInterframe + 1) {
+        				interframes.add(new FrameData());
+        			}
+                    FrameData lastInerframeData = interframes.get(lastInterframe);
+        			lastInerframeData.setData(data);
+    			} catch (Throwable e) {
+    				log.error("Failed to buffer interframe", e);
+    			}
     		}
     		// finished with the data, rewind one last time
     		data.rewind();
@@ -118,5 +146,14 @@ public class AVCVideo implements IVideoStreamCodec {
 	public IoBuffer getDecoderConfiguration() {
 		return decoderConfiguration.getFrame();
 	}
-	
+
+	/** {@inheritDoc} */
+	public int getNumInterframes() {
+		return numInterframes.get();
+	}
+
+	/** {@inheritDoc} */
+	public FrameData getInterframe(int index) {
+		return interframes.get(index);
+	}
 }

--- a/src/main/java/org/red5/codec/AVCVideo.java
+++ b/src/main/java/org/red5/codec/AVCVideo.java
@@ -125,8 +125,7 @@ public class AVCVideo implements IVideoStreamCodec {
         			if (interframes.size() < lastInterframe + 1) {
         				interframes.add(new FrameData());
         			}
-                    FrameData lastInerframeData = interframes.get(lastInterframe);
-        			lastInerframeData.setData(data);
+        			interframes.get(lastInterframe).setData(data);
     			} catch (Throwable e) {
     				log.error("Failed to buffer interframe", e);
     			}

--- a/src/main/java/org/red5/codec/IVideoStreamCodec.java
+++ b/src/main/java/org/red5/codec/IVideoStreamCodec.java
@@ -74,6 +74,19 @@ public interface IVideoStreamCodec {
 	public IoBuffer getDecoderConfiguration();
 
 	/**
+	 * @return the number of interframes collected from last keyframe.
+	 */
+	public int getNumInterframes();
+
+	/**
+	 * Gets data of interframe with the specified index.
+	 *
+	 * @param index the index of interframe.
+	 * @return data of the interframe.
+	 */
+	public FrameData getInterframe(int index);
+
+	/**
 	 * Holder for video frame data.
 	 */
 	public final static class FrameData {
@@ -86,12 +99,10 @@ public interface IVideoStreamCodec {
 		 * @param data data
 		 */
 		public void setData(IoBuffer data) {
-			if (frame == null) {
-				frame = new byte[data.limit()];
-			} else {
+			if (frame != null) {
 				frame = null;
-				frame = new byte[data.limit()];
 			}
+			frame = new byte[data.limit()];
 			data.get(frame);
 		}
 
@@ -100,5 +111,4 @@ public interface IVideoStreamCodec {
 		}
 
 	}
-
 }

--- a/src/main/java/org/red5/codec/ScreenVideo.java
+++ b/src/main/java/org/red5/codec/ScreenVideo.java
@@ -247,5 +247,15 @@ public class ScreenVideo implements IVideoStreamCodec {
 	public IoBuffer getDecoderConfiguration() {
 		return null;
 	}
-    
+
+	/** {@inheritDoc} */
+	public int getNumInterframes() {
+		return 0;
+	}
+
+	/** {@inheritDoc} */
+	public FrameData getInterframe(int index) {
+		return null;
+	}
+
 }

--- a/src/main/java/org/red5/codec/ScreenVideo2.java
+++ b/src/main/java/org/red5/codec/ScreenVideo2.java
@@ -275,4 +275,14 @@ public class ScreenVideo2 implements IVideoStreamCodec {
 		return null;
 	}
     
+	/** {@inheritDoc} */
+	public int getNumInterframes() {
+		return 0;
+	}
+
+	/** {@inheritDoc} */
+	public FrameData getInterframe(int idx) {
+		return null;
+	}
+
 }

--- a/src/main/java/org/red5/codec/SorensonVideo.java
+++ b/src/main/java/org/red5/codec/SorensonVideo.java
@@ -18,7 +18,13 @@
 
 package org.red5.codec;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.mina.core.buffer.IoBuffer;
+import org.red5.io.IoConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Red5 video codec for the sorenson video format.
@@ -29,7 +35,9 @@ import org.apache.mina.core.buffer.IoBuffer;
  * @author Joachim Bauch (jojo@struktur.de)
  * @author Paul Gregoire (mondain@gmail.com) 
  */
-public class SorensonVideo implements IVideoStreamCodec {
+public class SorensonVideo implements IVideoStreamCodec, IoConstants {
+
+	private Logger log = LoggerFactory.getLogger(SorensonVideo.class);
 
     /**
      * Sorenson video codec constant
@@ -48,6 +56,16 @@ public class SorensonVideo implements IVideoStreamCodec {
      * Data block size
      */
 	private int blockSize;
+
+	/**
+	 * Storage for frames buffered since last key frame
+	 */
+	private final List<FrameData> interframes = new ArrayList<FrameData>(50);
+
+	/**
+	 * Number of frames buffered since last key frame
+	 */
+	private final AtomicInteger numInterframes = new AtomicInteger(0);
 
 	/** Constructs a new SorensonVideo. */
     public SorensonVideo() {
@@ -97,10 +115,29 @@ public class SorensonVideo implements IVideoStreamCodec {
 
 		byte first = data.get();
 		data.rewind();
-		if ((first & 0xf0) != FLV_FRAME_KEY) {
+
+		int frameType = (first & MASK_VIDEO_FRAMETYPE) >> 4;
+		if (frameType != FLAG_FRAMETYPE_KEYFRAME) {
 			// Not a keyframe
+			try {
+    			int lastInterframe = numInterframes.getAndIncrement();
+                if (lastInterframe != 0 || frameType != FLAG_FRAMETYPE_DISPOSABLE) {
+                    log.trace("Buffering interframe #{}", lastInterframe);
+                    if (interframes.size() < lastInterframe + 1) {
+                        interframes.add(new FrameData());
+                    }
+                    interframes.get(lastInterframe).setData(data);
+                } else {
+                    numInterframes.set(lastInterframe);
+                }
+			} catch (Throwable e) {
+				log.error("Failed to buffer interframe", e);
+			}
+            data.rewind();
 			return true;
 		}
+
+		numInterframes.set(0);
 
 		// Store last keyframe
 		this.dataCount = data.limit();
@@ -128,6 +165,15 @@ public class SorensonVideo implements IVideoStreamCodec {
     
 	public IoBuffer getDecoderConfiguration() {
 		return null;
-	}    
-    
+	}
+
+	/** {@inheritDoc} */
+	public int getNumInterframes() {
+		return numInterframes.get();
+	}
+
+	/** {@inheritDoc} */
+	public FrameData getInterframe(int index) {
+		return interframes.get(index);
+	}
 }

--- a/src/main/java/org/red5/codec/SorensonVideo.java
+++ b/src/main/java/org/red5/codec/SorensonVideo.java
@@ -68,7 +68,7 @@ public class SorensonVideo implements IVideoStreamCodec, IoConstants {
 	private final AtomicInteger numInterframes = new AtomicInteger(0);
 
 	/** Constructs a new SorensonVideo. */
-    public SorensonVideo() {
+	public SorensonVideo() {
 		this.reset();
 	}
 
@@ -120,20 +120,20 @@ public class SorensonVideo implements IVideoStreamCodec, IoConstants {
 		if (frameType != FLAG_FRAMETYPE_KEYFRAME) {
 			// Not a keyframe
 			try {
-    			int lastInterframe = numInterframes.getAndIncrement();
-                if (frameType != FLAG_FRAMETYPE_DISPOSABLE) {
-                    log.trace("Buffering interframe #{}", lastInterframe);
-                    if (interframes.size() < lastInterframe + 1) {
-                        interframes.add(new FrameData());
-                    }
-                    interframes.get(lastInterframe).setData(data);
-                } else {
-                    numInterframes.set(lastInterframe);
-                }
+				int lastInterframe = numInterframes.getAndIncrement();
+				if (frameType != FLAG_FRAMETYPE_DISPOSABLE) {
+					log.trace("Buffering interframe #{}", lastInterframe);
+					if (interframes.size() < lastInterframe + 1) {
+						interframes.add(new FrameData());
+					}
+					interframes.get(lastInterframe).setData(data);
+				} else {
+					numInterframes.set(lastInterframe);
+				}
 			} catch (Throwable e) {
 				log.error("Failed to buffer interframe", e);
 			}
-            data.rewind();
+			data.rewind();
 			return true;
 		}
 

--- a/src/main/java/org/red5/codec/SorensonVideo.java
+++ b/src/main/java/org/red5/codec/SorensonVideo.java
@@ -121,7 +121,7 @@ public class SorensonVideo implements IVideoStreamCodec, IoConstants {
 			// Not a keyframe
 			try {
     			int lastInterframe = numInterframes.getAndIncrement();
-                if (lastInterframe != 0 || frameType != FLAG_FRAMETYPE_DISPOSABLE) {
+                if (frameType != FLAG_FRAMETYPE_DISPOSABLE) {
                     log.trace("Buffering interframe #{}", lastInterframe);
                     if (interframes.size() < lastInterframe + 1) {
                         interframes.add(new FrameData());


### PR DESCRIPTION
We added changes in red5-server-common and red5-io projects (framebuffer braches) that let see buffered video (from previous key frame) when user starts playback between two keyframes. We made changes only in Sorenson and AVC codecs and added stubs for two other video codecs.

It is important feature for us because we have client with own implementation of AVC codec and it may have up to 15 seconds between two adjacent frames.